### PR TITLE
Improve stack trace file path matching

### DIFF
--- a/lib/utils/extractStacktrace.js
+++ b/lib/utils/extractStacktrace.js
@@ -1,15 +1,12 @@
 /**
  * Extracts the file path and line number from the stack trace.
- *
- * @format
  * @param stack {string} error stack trace
  * @returns {{path: string, line: string}} file path and line number
  */
-
 const extractStacktrace = (stack) => {
-  const [, path, line] = stack.match(/\/([\/\w-_\.@]+\.ts|.js):(\d*):(\d*)/)
+    const [, path, line] = stack.match(/\/([\/\w-_\.@]+\.ts|.js):(\d*):(\d*)/);
 
-  return { path: '/' + path, line }
-}
+    return { path: '/' + path, line };
+};
 
-module.exports = extractStacktrace
+module.exports = extractStacktrace;

--- a/lib/utils/extractStacktrace.js
+++ b/lib/utils/extractStacktrace.js
@@ -1,12 +1,15 @@
 /**
  * Extracts the file path and line number from the stack trace.
+ *
+ * @format
  * @param stack {string} error stack trace
  * @returns {{path: string, line: string}} file path and line number
  */
-const extractStacktrace = (stack) => {
-    const [, path, line] = stack.match(/\/([\/\w-_\.]+\.js):(\d*):(\d*)/);
-    
-    return { path: '/' + path, line };
-};
 
-module.exports = extractStacktrace;
+const extractStacktrace = (stack) => {
+  const [, path, line] = stack.match(/\/([\/\w-_\.@]+\.ts|.js):(\d*):(\d*)/)
+
+  return { path: '/' + path, line }
+}
+
+module.exports = extractStacktrace


### PR DESCRIPTION
I was working with the adapter in an Adonis 5 project and it couldn't pick file paths with the `.ts` extension nor paths with an `@` symbol.

This was giving an error as either a different file would be called (`.js` only) or the file path could not be resolved as a section of the path was ignored.

I made some changes to add that functionality.